### PR TITLE
Feature/refactor returning users

### DIFF
--- a/ingestion/connector/ga_chp_connector.py
+++ b/ingestion/connector/ga_chp_connector.py
@@ -146,8 +146,10 @@ class GoogleAnalytics:
                 data_rows = data_chunk['reports'][0]['data']['rows']
                 meta = data_chunk['reports'][0]['columnHeader']
                 d_names_list = meta['dimensions']
-                m_names_list = [m_meta_dict['name'] for m_meta_dict in meta['metricHeader']['metricHeaderEntries']]
-                meta_dict = {'dimensions': d_names_list, 'metrics': m_names_list}
+                m_names_list = [m_meta_dict['name']
+                                for m_meta_dict in meta['metricHeader']['metricHeaderEntries']]
+                meta_dict = {'dimensions': d_names_list,
+                             'metrics': m_names_list}
             except Exception as ex:
                 print('BEGIN EXCEPTION')
                 print(report_type)
@@ -173,7 +175,17 @@ class GoogleAnalytics:
         metrics = ['sessions', 'sessionDuration', 'entrances',
                    'bounces', 'exits', 'pageValue', 'pageLoadTime', 'pageLoadSample']
 
-        return self.run_report_and_store('users', dimensions, metrics)
+        dimensions_filters = [
+            {
+                'filters': {
+                    'dimensionName': 'ga:userType',
+                    'operator': 'EXACT',
+                    'expressions': ['Returning Visitor']
+                },
+            },
+        ]
+
+        return self.run_report_and_store('users', dimensions, metrics, dimensions_filters)
 
     # Get churned users with additional session data
     def store_sessions(self):
@@ -182,7 +194,17 @@ class GoogleAnalytics:
         metrics = ['sessions', 'pageviews', 'uniquePageviews',
                    'screenViews', 'hits', 'timeOnPage']
 
-        return self.run_report_and_store('sessions', dimensions, metrics)
+        dimensions_filters = [
+            {
+                'filters': {
+                    'dimensionName': 'ga:userType',
+                    'operator': 'EXACT',
+                    'expressions': ['Returning Visitor']
+                },
+            },
+        ]
+
+        return self.run_report_and_store('sessions', dimensions, metrics, dimensions_filters)
 
     def run(self):
         self.authenticate()

--- a/pre_processing/basic_processing/ga_chp_basic_preprocessor.py
+++ b/pre_processing/basic_processing/ga_chp_basic_preprocessor.py
@@ -410,11 +410,6 @@ def main():
          .options(**save_options_ga_chp_features_raw)
          .save())
 
-    # Retained users
-    higher_session_counts_sql = 'SELECT * FROM features_raw WHERE session_count > 1'
-    higher_session_counts_df = spark_session.sql(higher_session_counts_sql)
-    higher_session_counts_df.createOrReplaceTempView('higher_session_counts')
-
     # Using window functions: https://databricks.com/blog/2015/07/15/introducing-window-functions-in-spark-sql.html
     grouped_by_client_id_before_dedup_sql_parts = [
         'SELECT',
@@ -435,7 +430,7 @@ def main():
         'ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY day_of_data_capture DESC) AS rownum,',
         'AVG(days_since_last_session) OVER (PARTITION BY client_id) AS avgdays',
         'FROM',
-        'higher_session_counts'
+        'features_raw'
     ]
     grouped_by_client_id_before_dedup_sql = ' '.join(grouped_by_client_id_before_dedup_sql_parts)
     grouped_by_client_id_before_dedup_df = spark_session.sql(grouped_by_client_id_before_dedup_sql)

--- a/pre_processing/scaling_transformation/scaler_transformer.py
+++ b/pre_processing/scaling_transformation/scaler_transformer.py
@@ -84,7 +84,8 @@ class ScalerTransformer:
 
         bc_array = np.array(bc_list).transpose()
 
-        transformed_bc_data = dd.from_array(bc_array, columns=self.num_labels)
+        transformed_bc_data = dd.from_array(
+            bc_array, chunksize=1000000, columns=self.num_labels)
 
         # Generate a similar .pkl file name and path for the 'Pipeline' type object with the fitted hyperparameters.
         pkl_file = f'{self.models_dir}/{self.day_as_str}_{self.unique_hash}_ga_chp_pipeline.pkl'
@@ -108,7 +109,7 @@ class ScalerTransformer:
             joblib.dump(pipeline, pkl_file)
             transformed_numeric = pipeline.transform(transformed_bc_data)
 
-        return dd.from_array(transformed_numeric, columns=self.num_labels)
+        return dd.from_array(transformed_numeric, chunksize=1000000, columns=self.num_labels)
 
     def get_transformed_gauss_data(self):
         """Applies the natural logarithm of 1 plus the value for the time related columns.
@@ -125,7 +126,7 @@ class ScalerTransformer:
             logged_data[column] = np.log1p(self.dask_df[column])
 
         logged_data_array = np.array(logged_data)
-        return dd.from_array(logged_data_array, columns=self.gauss_labels)
+        return dd.from_array(logged_data_array, chunksize=1000000, columns=self.gauss_labels)
 
     def get_churned_data(self):
         """Slices the 'churned' column from the dataframe and returns it.
@@ -134,7 +135,7 @@ class ScalerTransformer:
             A dask dataframe with the 'churned' column.
         """
         churned_data_array = np.array(self.dask_df['churned'])
-        return dd.from_array(churned_data_array, columns=['churned'])
+        return dd.from_array(churned_data_array, chunksize=1000000, columns=['churned'])
 
     def get_cat_data(self):
         """Slices the categorical columns from the dask dataframe and returns them.
@@ -143,7 +144,7 @@ class ScalerTransformer:
             A dask dataframe with the categorical columns.
         """
         cat_data_array = np.array(self.dask_df[self.cat_labels])
-        return dd.from_array(cat_data_array, columns=self.cat_labels)
+        return dd.from_array(cat_data_array, chunksize=1000000, columns=self.cat_labels)
 
     def get_client_id_data(self):
         """Slices the 'client_id' column from the dask dataframe and returns it.
@@ -152,7 +153,7 @@ class ScalerTransformer:
             A dask dataframe with the 'client_id' column.
         """
         client_id_data_array = np.array(self.dask_df['client_id'])
-        return dd.from_array(client_id_data_array, columns=['client_id'])
+        return dd.from_array(client_id_data_array, chunksize=1000000, columns=['client_id'])
 
     def get_transformed_data(self):
         """Calls all the methods to transform the data then concatenates the dataframes.

--- a/pre_processing/scaling_transformation/scaler_transformer.py
+++ b/pre_processing/scaling_transformation/scaler_transformer.py
@@ -85,7 +85,7 @@ class ScalerTransformer:
         bc_array = np.array(bc_list).transpose()
 
         transformed_bc_data = dd.from_array(
-            bc_array, chunksize=1000000, columns=self.num_labels)
+            bc_array, chunksize=200000, columns=self.num_labels)
 
         # Generate a similar .pkl file name and path for the 'Pipeline' type object with the fitted hyperparameters.
         pkl_file = f'{self.models_dir}/{self.day_as_str}_{self.unique_hash}_ga_chp_pipeline.pkl'
@@ -109,7 +109,7 @@ class ScalerTransformer:
             joblib.dump(pipeline, pkl_file)
             transformed_numeric = pipeline.transform(transformed_bc_data)
 
-        return dd.from_array(transformed_numeric, chunksize=1000000, columns=self.num_labels)
+        return dd.from_array(transformed_numeric, chunksize=200000, columns=self.num_labels)
 
     def get_transformed_gauss_data(self):
         """Applies the natural logarithm of 1 plus the value for the time related columns.
@@ -126,7 +126,7 @@ class ScalerTransformer:
             logged_data[column] = np.log1p(self.dask_df[column])
 
         logged_data_array = np.array(logged_data)
-        return dd.from_array(logged_data_array, chunksize=1000000, columns=self.gauss_labels)
+        return dd.from_array(logged_data_array, chunksize=200000, columns=self.gauss_labels)
 
     def get_churned_data(self):
         """Slices the 'churned' column from the dataframe and returns it.
@@ -135,7 +135,7 @@ class ScalerTransformer:
             A dask dataframe with the 'churned' column.
         """
         churned_data_array = np.array(self.dask_df['churned'])
-        return dd.from_array(churned_data_array, chunksize=1000000, columns=['churned'])
+        return dd.from_array(churned_data_array, chunksize=200000, columns=['churned'])
 
     def get_cat_data(self):
         """Slices the categorical columns from the dask dataframe and returns them.
@@ -144,7 +144,7 @@ class ScalerTransformer:
             A dask dataframe with the categorical columns.
         """
         cat_data_array = np.array(self.dask_df[self.cat_labels])
-        return dd.from_array(cat_data_array, chunksize=1000000, columns=self.cat_labels)
+        return dd.from_array(cat_data_array, chunksize=200000, columns=self.cat_labels)
 
     def get_client_id_data(self):
         """Slices the 'client_id' column from the dask dataframe and returns it.
@@ -153,7 +153,7 @@ class ScalerTransformer:
             A dask dataframe with the 'client_id' column.
         """
         client_id_data_array = np.array(self.dask_df['client_id'])
-        return dd.from_array(client_id_data_array, chunksize=1000000, columns=['client_id'])
+        return dd.from_array(client_id_data_array, chunksize=200000, columns=['client_id'])
 
     def get_transformed_data(self):
         """Calls all the methods to transform the data then concatenates the dataframes.

--- a/prediction/batch_inference/runbatchinference.sh
+++ b/prediction/batch_inference/runbatchinference.sh
@@ -1,5 +1,5 @@
 cp -r /opt/ga_chp /opt/code
 cd /opt/code
 git pull
-python /opt/ga_chp/prediction/batch_inference/ga_chp_batch_inference.py
+python /opt/code/prediction/batch_inference/ga_chp_batch_inference.py
 


### PR DESCRIPTION
The purpose of this PR is to fix the limitations of the predictions window, where users need to have at least 2 sessions in that window to be considered returning.

- Filter returning users when requesting data from Google Analytics API (ingestion pipeline)
- Remove `sessions > 2` condition from PySpark basic pre-processor
- Fix limitation of 50000 rows per predictions batch in the Dask advanced pre-processor