### PR TITLE
Remove returning user type condition from ingestion

### DIFF
--- a/ingestion/connector/ga_chp_connector.py
+++ b/ingestion/connector/ga_chp_connector.py
@@ -175,17 +175,7 @@ class GoogleAnalytics:
         metrics = ['sessions', 'sessionDuration', 'entrances',
                    'bounces', 'exits', 'pageValue', 'pageLoadTime', 'pageLoadSample']
 
-        dimensions_filters = [
-            {
-                'filters': {
-                    'dimensionName': 'ga:userType',
-                    'operator': 'EXACT',
-                    'expressions': ['Returning Visitor']
-                },
-            },
-        ]
-
-        return self.run_report_and_store('users', dimensions, metrics, dimensions_filters)
+        return self.run_report_and_store('users', dimensions, metrics)
 
     # Get churned users with additional session data
     def store_sessions(self):
@@ -194,17 +184,7 @@ class GoogleAnalytics:
         metrics = ['sessions', 'pageviews', 'uniquePageviews',
                    'screenViews', 'hits', 'timeOnPage']
 
-        dimensions_filters = [
-            {
-                'filters': {
-                    'dimensionName': 'ga:userType',
-                    'operator': 'EXACT',
-                    'expressions': ['Returning Visitor']
-                },
-            },
-        ]
-
-        return self.run_report_and_store('sessions', dimensions, metrics, dimensions_filters)
+        return self.run_report_and_store('sessions', dimensions, metrics)
 
     def run(self):
         self.authenticate()


### PR DESCRIPTION
Remove the `Returning Visitor` condition when retrieving data from Google Analytics. This allows importing `New Visitors`, with the assumption that by the time they will be targeted with predictions, they would have converted to `Returning Visitors`. For all cases, a minimum of two visits are required for generating predictions & targeting the user.